### PR TITLE
add check for existence of go.mod file

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/rogpeppe/go-internal v1.1.0 h1:g0fH8RicVgNl+zVZDCDfbdWxAWoAEJyI7I3TZYXFiig=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/modfile/modfile.go
+++ b/modfile/modfile.go
@@ -46,9 +46,8 @@ type Replace struct {
 func Parse(goModFilepath string) (File, error) {
 	var result File
 	out, err := exec.Command("go", "mod", "edit", "-json", goModFilepath).Output()
-
 	if err != nil {
-		return result, fmt.Errorf("error invoking 'go mod edit -json': %v", err)
+		return result, fmt.Errorf("error invoking 'go mod edit -json %s': %v", goModFilepath, err)
 	}
 
 	dec := json.NewDecoder(bytes.NewReader(out))


### PR DESCRIPTION
PR adds a workaround for the problem that `gomodvet -replace=false` fails with the error
`gomodvet: excludedversion: error invoking 'go mod edit -json': exit status 1`.  Adding a name of the go.mod file in `Parse` function in modfile/modfile.go shows:
```
gomodvet: excludedversion: error invoking 'go mod edit -json /Users/dmitris/go/pkg/mod/git.ourcompany.com/gitmirror/!burnt!sushi--toml@v0.3.1/go.mod': exit status 1
```
(`go.mod` file requires `github.com/BurntSushi/toml v0.3.1` and has a replace statement: `github.com/BurntSushi/toml v0.3.1 => git.ourcompany.com/gitmirror/BurntSushi--toml v0.3.1`).

With the current change, `gomodvet` runs fine, with `-v` verbose flag it prints the names of the non-existing `go.mod` files:
```
$ gomodvet -replace=false
[...]
gomodvet-005: go.mod file /Users/dmitris/go/pkg/mod/git.ourcompany.com/gitmirror/!burnt!sushi--toml@v0.3.1/go.mod doesn't exist
```